### PR TITLE
Bump to v0.7.0

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -13,10 +13,10 @@ engine:                      # engine settings
     Move Overhead: 5000      # increase if your bot flags games too often. 5000 is the highest accepted value.
     Threads: 2               # max CPU threads the engine can use
     USI_Hash: 256            # max memory (in megabytes) the engine can allocate
-#   go_commands:             # additional options to pass to the USI go command
-#     nodes: 1               # Search so many nodes only.
-#     depth: 5               # Search depth ply only.
-#     movetime: 1000         # Integer. Search exactly movetime milliseconds.
+#  go_commands:              # additional options to pass to the USI go command
+#    nodes: 1                # Search so many nodes only.
+#    depth: 5                # Search depth ply only.
+#    movetime: 1000          # Integer. Search exactly movetime milliseconds.
   silence_stderr: false      # some engines are very noisy
 
 abort_time: 30               # time to abort a game in seconds when there is no activity

--- a/conversation.py
+++ b/conversation.py
@@ -20,7 +20,7 @@ class Conversation:
             game.ping(60, 120)
             self.send_reply(line, "Waiting 60 seconds...")
         elif cmd == "name":
-            self.send_reply(line, "{} (lishogi-bot v{})".format(self.engine.name(), self.version))
+            self.send_reply(line, "lishogi-bot v0.7.0)
         elif cmd == "howto":
             self.send_reply(line, "How to run your own bot: https://github.com/TheYoBots/Lishogi-Bot")
         elif cmd == "eval" and line.room == "spectator":

--- a/conversation.py
+++ b/conversation.py
@@ -20,7 +20,7 @@ class Conversation:
             game.ping(60, 120)
             self.send_reply(line, "Waiting 60 seconds...")
         elif cmd == "name":
-            self.send_reply(line, "lishogi-bot v0.7.0)
+            self.send_reply(line, "lishogi-bot v0.7.0")
         elif cmd == "howto":
             self.send_reply(line, "How to run your own bot: https://github.com/TheYoBots/Lishogi-Bot")
         elif cmd == "eval" and line.room == "spectator":

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -64,7 +64,7 @@ class EngineWrapper:
 
 class USIEngine(EngineWrapper):
 
-   def __init__(self, board, commands, options, go_commands={}, silence_stderr=False):
+    def __init__(self, board, commands, options, go_commands={}, silence_stderr=False):
         commands = commands[0] if len(commands) == 1 else commands        
         self.go_commands = go_commands
 

--- a/lishogi-bot.py
+++ b/lishogi-bot.py
@@ -30,7 +30,7 @@ try:
 except ImportError:
     from http.client import BadStatusLine as RemoteDisconnected
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 terminated = False
 


### PR DESCRIPTION
There were several problems with sending custom go commands to the engine.

- Go commands config was not even sent to engine init ( only uci options ).

- An attempt was only made to read those setting in normal search, but this is never called ( only search with ponder option is ever called ).

- In config go command options were misaligned, making for invalid yml.

All those problems are fixed in this PR by sending the go command options to engine init, by adding an option to search with ponder, which ignores thinking times if any of the possible go command options is set, and sends the custom go command instead, and by aligning config.yml properly.

Thanks to https://github.com/ShailChoksi/lichess-bot/pull/258
