### PR TITLE
Enforce concurrent game limit to recover from event stream disconnections

### DIFF
--- a/engine_ctrl/usi.py
+++ b/engine_ctrl/usi.py
@@ -125,7 +125,6 @@ class Engine:
         self.send("setoption name %s value %s" % (name, value))
 
     def set_variant_options(self, variant):
-        variant = variant.lower()
         if variant in ["standard"]:
             self.setoption("USI_Variant", "shogi")
         else:

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -56,6 +56,7 @@ class EngineWrapper:
     def search_for(self, board, game, movetime):
         moves = "" if game.variant_name == "Standard" else game.state["moves"].split()
         sfen = board.sfen() if game.variant_name == "Standard" else game.initial_sfen
+        self.engine.set_variant_options(game.variant_name.lower())
         return self.search(sfen, moves, movetime=movetime // 1000)
     
     def search_with_ponder(self, game, board, btime, wtime, binc, winc, byo, ponder=False):

--- a/lishogi-bot.py
+++ b/lishogi-bot.py
@@ -24,7 +24,7 @@ from http.client import RemoteDisconnected
 
 logger = logging.getLogger(__name__)
 
-__version__ = "1.1.2"
+__version__ = "1.1.1"
 
 terminated = False
 

--- a/lishogi-bot.py
+++ b/lishogi-bot.py
@@ -53,14 +53,14 @@ def upgrade_account(li):
 def watch_control_stream(control_queue, li):
     while not terminated:
         try:
-            response = li.get_event_stream()
-            lines = response.iter_lines()
-            for line in lines:
-                if line:
-                    event = json.loads(line.decode("utf-8"))
-                    control_queue.put_nowait(event)
-                else:
-                    control_queue.put_nowait({"type": "ping"})
+            with li.get_event_stream() as response:
+                lines = response.iter_lines()
+                for line in lines:
+                    if line:
+                        event = json.loads(line.decode("utf-8"))
+                        control_queue.put_nowait(event)
+                    else:
+                        control_queue.put_nowait({"type": "ping"})
         except:
             pass
 
@@ -127,7 +127,9 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
     correspondence_pinger.start()
     correspondence_queue = manager.Queue()
     correspondence_queue.put("")
-    startup_correspondence_games = [game["gameId"] for game in li.get_ongoing_games() if game["perf"] == "correspondence"]
+    ongoing_games = li.get_ongoing_games()
+    startup_correspondence_games = [game["gameId"] for game in ongoing_games if game["perf"] == "correspondence"]
+    startup_ponder_games = [game["gameId"] for game in ongoing_games if not game["isMyTurn"]]
     wait_for_correspondence_ping = False
 
     busy_processes = 0
@@ -142,6 +144,7 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
         while not terminated:
             try:
                 event = control_queue.get()
+                logger.debug(f"Event: {event}")
             except InterruptedError:
                 continue
 
@@ -175,10 +178,12 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
                         pass
             elif event["type"] == "gameStart":
                 game_id = event["game"]["id"]
-                if busy_processes >= max_games:
+                # future work: do not ponder using play_game if pondering is disabled
+                engine_cfg = config["engine"]
+                if busy_processes >= max_games or (engine_can_ponder(correspondence_cfg, engine_cfg, game_id in startup_correspondence_games) and game_id in startup_ponder_games):
                     # if during error recovery too many games are in progress, do not panic
+                    logger.info(f'--- Enqueue {config["url"] + game_id}')
                     if game_id not in startup_correspondence_games:
-                        logger.info(f'--- Ignore {config["url"] + game_id}')
                         startup_correspondence_games.append(game_id)
                 elif game_id in startup_correspondence_games:
                     logger.info(f'--- Enqueue {config["url"] + game_id}')
@@ -238,6 +243,11 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
 ponder_results = {}
 
 
+def engine_can_ponder(correspondence_cfg, engine_cfg, is_correspondence):
+    ponder_cfg = correspondence_cfg if is_correspondence else engine_cfg
+    return ponder_cfg.get("ponder", False)
+
+
 @backoff.on_exception(backoff.expo, BaseException, max_time=600, giveup=is_final)
 def play_game(li, game_id, control_queue, user_profile, config, challenge_queue, correspondence_queue, logging_queue, game_logging_configurer, logging_level):
     game_logging_configurer(logging_queue, logging_level)
@@ -254,15 +264,14 @@ def play_game(li, game_id, control_queue, user_profile, config, challenge_queue,
     engine.get_opponent_info(game)
     conversation = Conversation(game, engine, li, __version__, challenge_queue)
 
-    logger.info(f"+++ {game}")
+    logger.info(f"+++ Playing {game}")
 
     is_correspondence = game.perf_name == "Correspondence"
     correspondence_cfg = config.get("correspondence") or {}
     correspondence_move_time = correspondence_cfg.get("move_time", 60) * 1000
 
     engine_cfg = config["engine"]
-    ponder_cfg = correspondence_cfg if is_correspondence else engine_cfg
-    can_ponder = ponder_cfg.get("ponder", False)
+    can_ponder = engine_can_ponder(correspondence_cfg, engine_cfg, is_correspondence)
     move_overhead = config.get("move_overhead", 1000)
     delay_seconds = config.get("rate_limiting_delay", 0)/1000
     online_moves_cfg = engine_cfg.get("online_moves", {})
@@ -311,7 +320,8 @@ def play_game(li, game_id, control_queue, user_profile, config, challenge_queue,
                     correspondence_disconnect_time = correspondence_cfg.get("disconnect_time", 300)
 
                     if len(board.move_stack) < 2:
-                        best_move, ponder_move = choose_first_move(engine, board, game)
+                        # need to hardcode first movetime since Lishogi has 30 sec limit
+                        best_move, ponder_move = choose_move_time(engine, board, game, 1000)
                     elif is_correspondence:
                         best_move, ponder_move = choose_move_time(engine, board, game, correspondence_move_time)
                     else:
@@ -319,10 +329,11 @@ def play_game(li, game_id, control_queue, user_profile, config, challenge_queue,
                         move_attempted = True
                         if best_move is None:
                             best_move, ponder_move = play_midgame_move(engine, board, upd["btime"], upd["wtime"], move_overhead, start_time, logger, game)
-                        if best_move is None:
-                            best_move, ponder_move = get_online_move(li, board, game, online_moves_cfg)
+                            if best_move is None:
+                                best_move, ponder_move = get_online_move(li, board, game, online_moves_cfg)
                     li.make_move(game.id, best_move)
-                    ponder_thread, ponder_usi = start_pondering(engine, board, best_move, ponder_move, upd["btime"], upd["wtime"], game, logger, move_overhead, start_time, can_ponder)
+                    if can_ponder:
+                        ponder_thread, ponder_usi = start_pondering(engine, board, best_move, ponder_move, upd["btime"], upd["wtime"], game, logger, move_overhead, start_time, can_ponder)
                     time.sleep(delay_seconds)
                 elif len(board.move_stack) == 0:
                     correspondence_disconnect_time = correspondence_cfg.get("disconnect_time", 300)
@@ -334,7 +345,7 @@ def play_game(li, game_id, control_queue, user_profile, config, challenge_queue,
                 if is_correspondence and not is_engine_move(game, board) and game.should_disconnect_now():
                     break
                 elif game.should_abort_now():
-                    logger.info(f"Aborting {game.url()} by lack of activity")
+                    logger.info(f"Aborting [{game.url()}] by lack of activity")
                     li.abort(game.id)
                     break
                 elif game.should_terminate_now():
@@ -476,11 +487,6 @@ def get_online_move(li, board, best_move, game, online_moves_cfg):
 def choose_move_time(engine, board, game, search_time):
     logger.info(f"Searching for time {search_time}")
     return engine.search_for(board, game, search_time)
-
-
-def choose_first_move(engine, board, game):
-    # need to hardcode first movetime since Lishogi has 30 sec limit.
-    return choose_move_time(engine, board, game, 1000)
 
 
 def fake_thinking(config, board, game):

--- a/lishogi.py
+++ b/lishogi.py
@@ -60,7 +60,7 @@ class Lishogi:
     def api_get(self, path, raise_for_status=True, timeout=2):
         logging.getLogger("backoff").setLevel(self.logging_level)
         url = urljoin(self.baseUrl, path)
-        logger.debug(url)
+        logger.info("GET [%s]", url)
         response = self.session.get(url, timeout=timeout)
         if rate_limit_check(response) or raise_for_status:
             response.raise_for_status()
@@ -77,7 +77,7 @@ class Lishogi:
     def api_post(self, path, data=None, raise_for_status=True, timeout=2):
         logging.getLogger("backoff").setLevel(self.logging_level)
         url = urljoin(self.baseUrl, path)
-        logger.debug(url)
+        logger.info("POST [%s] %s", url, data) if data else logger.info("POST [%s]", url)
         response = self.session.post(url, data=data, timeout=timeout)
         if rate_limit_check(response) or raise_for_status:
             response.raise_for_status()
@@ -131,5 +131,5 @@ class Lishogi:
         self.session.headers.update(self.header)
 
     def challenge_ai(self):
-        challenge = {"level": 1, "clock.limit": 60, "clock.increment": 0, "clock.byoyomi": 2, "clock.periods": 1}
+        challenge = {"level": 1, "clock.limit": 60, "clock.increment": 2, "clock.byoyomi": 0, "clock.periods": 1}
         return self.api_post(ENDPOINTS["challenge_ai"], data=challenge, timeout=30)

--- a/lishogi.py
+++ b/lishogi.py
@@ -102,10 +102,12 @@ class Lishogi:
 
     def get_event_stream(self):
         url = urljoin(self.baseUrl, ENDPOINTS["stream_event"])
+        logger.info("GET [%s]", url)
         return requests.get(url, headers=self.header, stream=True)
 
     def get_game_stream(self, game_id):
         url = urljoin(self.baseUrl, ENDPOINTS["stream"].format(game_id))
+        logger.info("GET [%s]", url)
         return requests.get(url, headers=self.header, stream=True)
 
     def accept_challenge(self, challenge_id):

--- a/lishogi.py
+++ b/lishogi.py
@@ -60,7 +60,7 @@ class Lishogi:
     def api_get(self, path, raise_for_status=True, timeout=2):
         logging.getLogger("backoff").setLevel(self.logging_level)
         url = urljoin(self.baseUrl, path)
-        logger.info("GET %s", url)
+        logger.debug("GET %s", url)
         response = self.session.get(url, timeout=timeout)
         if rate_limit_check(response) or raise_for_status:
             response.raise_for_status()
@@ -77,7 +77,7 @@ class Lishogi:
     def api_post(self, path, data=None, raise_for_status=True, timeout=2):
         logging.getLogger("backoff").setLevel(self.logging_level)
         url = urljoin(self.baseUrl, path)
-        logger.info("POST %s %s", url, data) if data else logger.info("POST %s", url)
+        logger.debug("POST %s %s", url, data) if data else logger.debug("POST %s", url)
         response = self.session.post(url, data=data, timeout=timeout)
         if rate_limit_check(response) or raise_for_status:
             response.raise_for_status()
@@ -102,12 +102,12 @@ class Lishogi:
 
     def get_event_stream(self):
         url = urljoin(self.baseUrl, ENDPOINTS["stream_event"])
-        logger.info("GET %s", url)
+        logger.debug("GET %s", url)
         return requests.get(url, headers=self.header, stream=True)
 
     def get_game_stream(self, game_id):
         url = urljoin(self.baseUrl, ENDPOINTS["stream"].format(game_id))
-        logger.info("GET %s", url)
+        logger.debug("GET %s", url)
         return requests.get(url, headers=self.header, stream=True)
 
     def accept_challenge(self, challenge_id):

--- a/lishogi.py
+++ b/lishogi.py
@@ -60,7 +60,7 @@ class Lishogi:
     def api_get(self, path, raise_for_status=True, timeout=2):
         logging.getLogger("backoff").setLevel(self.logging_level)
         url = urljoin(self.baseUrl, path)
-        logger.info("GET [%s]", url)
+        logger.info("GET %s", url)
         response = self.session.get(url, timeout=timeout)
         if rate_limit_check(response) or raise_for_status:
             response.raise_for_status()
@@ -77,7 +77,7 @@ class Lishogi:
     def api_post(self, path, data=None, raise_for_status=True, timeout=2):
         logging.getLogger("backoff").setLevel(self.logging_level)
         url = urljoin(self.baseUrl, path)
-        logger.info("POST [%s] %s", url, data) if data else logger.info("POST [%s]", url)
+        logger.info("POST %s %s", url, data) if data else logger.info("POST %s", url)
         response = self.session.post(url, data=data, timeout=timeout)
         if rate_limit_check(response) or raise_for_status:
             response.raise_for_status()
@@ -102,12 +102,12 @@ class Lishogi:
 
     def get_event_stream(self):
         url = urljoin(self.baseUrl, ENDPOINTS["stream_event"])
-        logger.info("GET [%s]", url)
+        logger.info("GET %s", url)
         return requests.get(url, headers=self.header, stream=True)
 
     def get_game_stream(self, game_id):
         url = urljoin(self.baseUrl, ENDPOINTS["stream"].format(game_id))
-        logger.info("GET [%s]", url)
+        logger.info("GET %s", url)
         return requests.get(url, headers=self.header, stream=True)
 
     def accept_challenge(self, challenge_id):

--- a/tests.py
+++ b/tests.py
@@ -41,15 +41,6 @@ def run_bot(CONFIG, logging_level):
             time.sleep(60)
         game_id = li.challenge_ai()["id"]
         time.sleep(2)
-        games = li.get_ongoing_games()
-        game_ids = list(map(lambda game: game["gameId"], games))
-        for game in game_ids:
-            if game != game_id:
-                try:
-                    li.abort(game)
-                except:
-                    pass
-                time.sleep(2)
 
         @pytest.mark.timeout(300)
         def run_test():
@@ -74,13 +65,14 @@ def run_bot(CONFIG, logging_level):
 
 
 def test_bot():
-    logging_level = lishogi_bot.logging.INFO  # lishogi_bot.logging_level.DEBUG
+    logging_level = lishogi_bot.logging.INFO
     lishogi_bot.logging_configurer(logging_level, None)
     with open("./config.yml.default") as file:
         CONFIG = yaml.safe_load(file)
     CONFIG["token"] = TOKEN
     CONFIG["engine"]["dir"] = "/usr/games"
     CONFIG["engine"]["name"] = "fairy-stockfish"
+    CONFIG["engine"]["protocol"] = "usi"
     CONFIG["engine"]["go_commands"] = {}
     CONFIG["engine"]["go_commands"]["nodes"] = "100000"
     run_bot(CONFIG, logging_level)


### PR DESCRIPTION
The game event stream seems to be repeating the same `gameStart` event hundreds of times, but there is no need to spawn hundreds of engines.