### PR TITLE
Fix various USI issues

### DIFF
--- a/config.yml.default
+++ b/config.yml.default
@@ -28,6 +28,7 @@ engine:                                              # Engine Settings.
 #   depth: 5                                         # Search depth ply only.
 #   movetime: 1000                                   # Integer. Search exactly movetime milliseconds.
   silence_stderr: false                              # Some engines are very noisy.
+  startup_lines: 0                                   # Some engines print their title unprompted. Set to the number of lines to ignore on startup. 
 
 abort_time: 30                                       # Time in seconds after which the engine will abort the game if there is no activity.
 fake_think_time: false                               # Artificially slow down the bot to pretend like it's thinking.

--- a/config.yml.default
+++ b/config.yml.default
@@ -58,6 +58,7 @@ challenge:                                           # Incoming challenges.
 #   - chushogi
 #   - annanshogi
 #   - kyotoshogi
+#   - checkshogi
   time_controls:                                     # Time controls to accept.
     - ultraBullet
     - bullet

--- a/engine_ctrl/usi.py
+++ b/engine_ctrl/usi.py
@@ -95,9 +95,6 @@ class Engine:
                     engine_info[name_and_value[0]] = name_and_value[1]
             elif command == "option":
                 pass
-            elif command == "Fairy-Stockfish" and " by " in arg:
-                # Ignore identification line
-                pass
             else:
                 logger.warning("Unexpected engine response to usi: %s %s" % (command, arg))
             self.id = engine_info

--- a/engine_ctrl/usi.py
+++ b/engine_ctrl/usi.py
@@ -14,6 +14,7 @@ class Engine:
         cwd = cwd or os.path.realpath(os.path.expanduser("."))
         self.proccess = self.open_process(command, cwd)
         self.go_commands = None
+        self.current_variant = None 
 
     def set_go_commands(self, go_comm):
         self.go_commands = go_comm
@@ -125,6 +126,12 @@ class Engine:
         self.send("setoption name %s value %s" % (name, value))
 
     def set_variant_options(self, variant):
+        # Some engines may unnecessarily reset board when selecting a variant
+        if self.current_variant == variant: 
+            return 
+        
+        self.current_variant = variant 
+
         if "fairy-stockfish" in self.id.get("name", "").lower():
             if variant in ["standard"]:
                 self.setoption("UCI_Variant", "shogi")

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -68,6 +68,7 @@ class EngineWrapper:
         else:
             moves = [m.usi() for m in list(board.move_stack)] if game.variant_name == "Standard" else game.state["moves"].split()
         sfen = game.initial_sfen
+        self.engine.set_variant_options(game.variant_name.lower())
         cmds = self.go_commands
         movetime = cmds.get("movetime")
         if movetime is not None:

--- a/engine_wrapper.py
+++ b/engine_wrapper.py
@@ -60,7 +60,7 @@ class EngineWrapper:
             moves = "" if game.variant_name == "Standard" else game.state["moves"].split()
         sfen = board.sfen() if game.variant_name == "Standard" else game.initial_sfen
         self.engine.set_variant_options(game.variant_name.lower())
-        return self.search(sfen, moves, movetime=movetime // 1000)
+        return self.search(sfen, moves, movetime=movetime)
     
     def search_with_ponder(self, game, board, btime, wtime, binc, winc, byo, ponder=False):
         if game.variant_name == "Kyoto shogi":
@@ -71,7 +71,7 @@ class EngineWrapper:
         cmds = self.go_commands
         movetime = cmds.get("movetime")
         if movetime is not None:
-            movetime = float(movetime) / 1000
+            movetime = float(movetime)
         best_move, ponder_move = self.search(sfen,
                                              moves,
                                              btime=btime,

--- a/lishogi-bot.py
+++ b/lishogi-bot.py
@@ -24,7 +24,7 @@ from http.client import RemoteDisconnected
 
 logger = logging.getLogger(__name__)
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 terminated = False
 


### PR DESCRIPTION
This fixes a few issues with USI engines: 

* During correspondence games, `movetime` was being provided as a number of seconds instead of milliseconds
* USI variant was not being set when the bot was started midgame, causing all midgame matches to be treated as if they were standard shogi
* Identification lines other than Fairy-Stockfish's would cause a warning

Additionally, I added checkshogi as a commented-out variant option so users are more aware that it is supported. 

Please let me know if you'd like anything changed! 